### PR TITLE
BB-29 removed spendings from the UI display. Only accounts displayed

### DIFF
--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -57,9 +57,6 @@ const accountList = accountsArr.map((account) => {
           <h2>Accounts</h2>
           {accountData ? accountList : "No accounts are available at this time"}
         </section>
-        <section className={[styles.barList, styles.diagonal].join(" ")}>
-          <SpendingList accounts={accounts} />
-        </section>
       </div>
     </main>
   );


### PR DESCRIPTION
Refactored design to show only accounts. Spending component removed from the home-page