### PR TITLE
BB-30 Refactor SpendingList component to use spendingData prop

### DIFF
--- a/src/components/SpendingList/SpendingList.jsx
+++ b/src/components/SpendingList/SpendingList.jsx
@@ -1,46 +1,41 @@
 // SpendingList component is used to display the spending list for each account in the AccountList component.
 // It's used in App.js to display the spending list for each account.
-// It takes one prop: accounts.
-import PropTypes from "prop-types";
+// It takes one prop: spendingData.
 import SpendingBar from "../SpendingBar/SpendingBar";
 import styles from "./SpendingList.module.css";
+import { setUsdCurrency } from "../../utilities";
 
-export default function SpendingList({ accounts }) {
-  // max is the maximum amount spent in any category
-  let max = Math.max(
-    ...accounts[0].spendings.map((cata) => {
-      return parseInt(cata.spent);
-    })
-  );
-  // categoryList generates a list of SpendingBar components
-  const categoryList = accounts[0].spendings.map((cata, index) => {
-    // percent is the percentage of the amount spent in each category
-    let percent = (parseInt(cata.spent) / max) * 100;
-
-    return (
-      <SpendingBar
-        key={index}
-        // this will make the bar look better and clear to compare the spending
-        percent={percent > 40 ? percent : (percent += 30)}
-      >
-        <span className={styles.barText}>{cata.category}</span>
-        <span className={styles.barText}>${cata.spent}</span>
-      </SpendingBar>
+// The component takes a spendingData prop. I put some default values in so I could test and build it.
+// Because I'm not sure how we will be rendering this prop. Once we start using it in the
+// app, we can remove the default values.
+export default function SpendingList({ spendingData = [{category: "Rent", spent: "1450"},{category: "Food", spent: "300"}, {category: "Netflix", spent: "20"}] }) {
+    // max is the maximum amount spent in any category
+    let max = Math.max(
+      ...spendingData.map((categoryObj) => {
+        return parseInt(categoryObj.spent);
+      })
     );
-  });
+    // categoryList generates a list of SpendingBar components
+    const categoryList = spendingData.map((categoryObj, index) => {
+      // percent is the percentage of the amount spent in each category
+      let percent = (parseInt(categoryObj.spent) / max) * 100;
+
+      return (
+        <SpendingBar
+          key={index}
+          // this will make the bar look better and clear to compare the spending
+          percent={percent > 40 ? percent : (percent += 30)}
+        >
+          <span className={styles.barText}>{categoryObj.category}</span>
+          <span className={styles.barText}>{setUsdCurrency(categoryObj.spent)}</span>
+        </SpendingBar>
+      );
+    });
+
 
   return (
     <>
-      <h2 className={styles.title}>Spending</h2>
       <div className={styles.barList}>{categoryList}</div>
     </>
   );
 }
-
-SpendingList.propTypes = {
-  accounts: PropTypes.arrayOf(
-    PropTypes.shape({
-      spendings: PropTypes.array.isRequired,
-    })
-  ).isRequired,
-};

--- a/src/components/SpendingList/SpendingList.jsx
+++ b/src/components/SpendingList/SpendingList.jsx
@@ -1,13 +1,9 @@
-// SpendingList component is used to display the spending list for each account in the AccountList component.
-// It's used in App.js to display the spending list for each account.
+// SpendingList component is used to generate the spending list.
 // It takes one prop: spendingData.
 import SpendingBar from "../SpendingBar/SpendingBar";
 import styles from "./SpendingList.module.css";
 import { setUsdCurrency } from "../../utilities";
 
-// The component takes a spendingData prop. I put some default values in so I could test and build it.
-// Because I'm not sure how we will be rendering this prop. Once we start using it in the
-// app, we can remove the default values.
 export default function SpendingList({ spendingData = [{category: "Rent", spent: "1450"},{category: "Food", spent: "300"}, {category: "Netflix", spent: "20"}] }) {
     // max is the maximum amount spent in any category
     let max = Math.max(

--- a/src/components/SpendingList/SpendingList.module.css
+++ b/src/components/SpendingList/SpendingList.module.css
@@ -1,7 +1,3 @@
-.title {
-  color: white;
-}
-
 .barList {
   width: 100%;
   display: flex;


### PR DESCRIPTION
Initially, this component got data/props passed down from HomePage.jsx and was removed in #7. It was getting all of the account data, so I adjusted it to take only the spending array. Also, I put default data for now to test it. If I need to remove it for this PR, let me know. There is a comment to remove the default data as a reminder. I removed the H2 title as this component's purpose is to generate spending bars; it isn't a full page in itself.